### PR TITLE
Remove deps/build.jl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,0 @@
-import Pkg; Pkg.add("Pkg")
-Pkg.add(url="https://github.com/OpenModelica/MetaModelica.jl.git")
-Pkg.resolve()


### PR DESCRIPTION
## Reason for Removal

The `deps/build.jl` script has become redundant as all dependencies are now properly specified in the `Project.toml` file. This change simplifies the project structure and dependency management process.

## Key Points

1. All required dependencies are listed in `Project.toml`, making `Pkg.add()` calls in `build.jl` unnecessary.
2. Julia's package manager can handle dependency installation and resolution using `Pkg.instantiate()` based on `Project.toml` alone.
3. Removing `build.jl` reduces maintenance overhead and potential conflicts between manually added packages and those specified in `Project.toml`.
4. For users and contributors, this change streamlines the setup process, relying solely on Julia's built-in package management capabilities.